### PR TITLE
Support small sized regions for H2

### DIFF
--- a/allocator/Makefile
+++ b/allocator/Makefile
@@ -14,7 +14,7 @@ include ./makefile.colors
 #rules
 .PHONY: all lib tc_allocate tc_group tc_free tc_sync tc_async clean distclean test depedencies
 
-all: tc_allocate tc_group tc_free tc_sync tc_async
+all: tc_allocate tc_group tc_free tc_sync tc_async tc_multi_region
 
 lib: $(REGIONSLIBRARY)
 
@@ -27,6 +27,12 @@ tc_free: $(TC_FREE_EXE)
 tc_sync: $(TC_SYNC_EXE)
 
 tc_async: $(TC_ASYNC_EXE)
+
+tc_multi_region: $(TC_ALLOCATE_MULTI_REGION_EXE)
+
+$(TC_ALLOCATE_MULTI_REGION_EXE): $(TC_ALLOCATE_MULTI_REGION) $(REGIONSLIBRARY)
+	@echo -e '[$(BYELLOW)LNK$(RESET)]' $^
+	@$(CC) $< $(REGIONSLIBRARY) $(OFLAG) $@ 
 
 $(TC_ALLOCATE_EXE): $(TC_ALLOCATE_OBJ) $(REGIONSLIBRARY)
 	@echo -e '[$(BYELLOW)LNK$(RESET)]' $^
@@ -82,11 +88,11 @@ uninstall:
 
 clean:
 	@echo -e '[$(BRED)RM$(RESET)]' $(TC_ALLOCATE_OBJ) $(TC_SYNC_OBJ) $(TC_ASYNC_OBJ) $(TC_GROUP_OBJ) $(TC_FREE_OBJ)
-	@$(RM) $(LIBREGIONSOBJS) $(TC_ALLOCATE_OBJ) $(TC_SYNC_OBJ) $(TC_ASYNC_OBJ) $(TC_GROUP_OBJ) $(TC_FREE_OBJ)
+	@$(RM) $(LIBREGIONSOBJS) $(TC_ALLOCATE_OBJ) $(TC_SYNC_OBJ) $(TC_ASYNC_OBJ) $(TC_GROUP_OBJ) $(TC_FREE_OBJ) $(TC_ALLOCATE_MULTI_REGION)
 
 distclean: clean
 	@echo -e '[$(BRED)RM$(RESET)]' $(TC_ALLOCATE_EXE) $(TC_SYNC_EXE) $(TC_ASYNC_EXE) $(TC_GROUP_EXE) $(TC_FREE_EXE)
-	@$(RM) $(TC_ALLOCATE_EXE) $(TC_SYNC_EXE) $(TC_ASYNC_EXE) $(TC_GROUP_EXE) $(TC_FREE_EXE)
+	@$(RM) $(TC_ALLOCATE_EXE) $(TC_SYNC_EXE) $(TC_ASYNC_EXE) $(TC_GROUP_EXE) $(TC_FREE_EXE) $(TC_ALLOCATE_MULTI_REGION_EXE)
 	@echo -e '[$(BRED)RM$(RESET)]' $(REGIONSLIBRARY)
 	@$(RM) $(REGIONSLIBRARY)
 	@echo -e '[$(BRED)RM$(RESET)]' $(LIBDIR)

--- a/allocator/Makefile_common.mk
+++ b/allocator/Makefile_common.mk
@@ -30,18 +30,20 @@ TC_GROUP_OBJ = $(TESTDIR)/tc_group.o
 TC_FREE_OBJ = $(TESTDIR)/tc_free.o
 TC_SYNC_OBJ = $(TESTDIR)/tc_sync_write.o
 TC_ASYNC_OBJ = $(TESTDIR)/tc_async_write.o
+TC_ALLOCATE_MULTI_REGION = $(TESTDIR)/tc_allocate_multi_regions.o
 
 TC_ALLOCATE_EXE = tc_allocate.bin
 TC_GROUP_EXE = tc_group.bin
 TC_FREE_EXE = tc_free.bin
 TC_SYNC_EXE = tc_sync_write.bin
 TC_ASYNC_EXE = tc_async_write.bin
+TC_ALLOCATE_MULTI_REGION_EXE = tc_allocate_multi_regions.bin
 
 CC = gcc
 
 ## Flags
 BINFLAG = -c
-DEBUGFLAG = -ggdb3
+DEBUGFLAG = -g
 OFLAG = -o
 WALLFLAG = -Wall -Werror -pedantic
 OPTIMZEFLAG = -O3

--- a/allocator/include/segments.h
+++ b/allocator/include/segments.h
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
+#define ANONYMOUS 0
 #define PR_BUFFER 1						
 #define PR_BUFFER_SIZE (2*1024LU*1024) /* Promotion buffer size */
 #define HeapWordSize 8				   /* Java heap allignment */
@@ -14,8 +15,8 @@
 #define THRESHOLD (1*1024LU*1024)	   
 
 struct offset{
-    uint64_t offset;
-    struct offset *next;
+  uint64_t offset;
+  struct offset *next;
 };
 
 #if PR_BUFFER
@@ -47,14 +48,16 @@ struct region{
     char *last_allocated_start;
     char *first_allocated_start;
     struct group *dependency_list;
-    struct offset *offset_list;
+#if ANONYMOUS
+  struct offset *offset_list;
+  size_t size_mapped; 
+#endif
 #if PR_BUFFER
     struct pr_buffer *pr_buffer;
 #endif
-    uint64_t used;
-    uint64_t rdd_id;
-    uint64_t part_id;
-    size_t size_mapped;
+    int8_t used;
+    uint32_t rdd_id;
+    uint32_t part_id;
 };
 
 /*
@@ -221,6 +224,23 @@ uint64_t get_obj_part_id(char *obj);
  * returns: 1 if objects are in the same group, 0 otherwise
  */
 int is_in_the_same_group(char *obj1, char *obj2);
+
+/*
+ * Get number of continious regions in H2
+ *
+ * addr: address of the object
+ */
+int get_num_of_continuous_regions(char *addr);
+
+/*
+ * Check if the objects starts from existing region
+ * 
+ * obj: object address
+ *
+ * returns: true if starts and false, otherwise
+ *
+ */
+bool object_starts_from_region(char *obj);
 
 #if PR_BUFFER
 /*

--- a/allocator/include/sharedDefines.h
+++ b/allocator/include/sharedDefines.h
@@ -7,7 +7,7 @@
 #include <stdio.h>
 
 #define DEV "/mnt/fmap/file.txt"	     //< Device name
-#define DEV_SIZE (150*1024LU*1024*1024)  //< Device size (in bytes)
+#define DEV_SIZE (700*1024LU*1024*1024)  //< Device size (in bytes)
 
 //#define ASSERT
 
@@ -19,7 +19,7 @@
 #define assertf(A, M, ...) ;
 #endif
 
-#define ANONYMOUS    0                //< Set to 1 for small mmaps
+#define ANONYMOUS  0                //< Set to 1 for small mmaps
 
 #define MAX_REQS	 64				  //< Maximum requests
 
@@ -27,23 +27,22 @@
 
 #define MALLOC_ON	1				  //< Allocate buffers dynamically
 
-#define REGION_SIZE	(256*1024LU*1024) //< Region size (in bytes) for allignment
-									  // version
-
-#define V_SPACE (100*1024LU*1024*1024*1024) //< Virtual address space size for 
-											// small mmaps
+#define REGION_SIZE	(16*1024LU*1024) //< Region size (in bytes) for allignment
+									                    // version
 
 #if ANONYMOUS
+#define V_SPACE (100*1024LU*1024*1024*1024) //< Virtual address space size for 
+											// small mmaps
 #define REGION_ARRAY_SIZE ((V_SPACE)/(REGION_SIZE))
 #define MAX_PARTITIONS 256			  // Maximum partitions per RDD, affects 
 									  // id array size
 
-#define MAX_RDD_ID 256				  //< Total different rdds
+#define MAX_RDD_ID ((REGION_ARRAY_SIZE)/(MAX_PARTITIONS)) //< Total different rdds
 
 #else
 #define REGION_ARRAY_SIZE ((DEV_SIZE)/(REGION_SIZE))
 
-#define MAX_PARTITIONS 1			  // Maximum partitions per RDD, affects 
+#define MAX_PARTITIONS 256			  // Maximum partitions per RDD, affects 
 									  // id array size
 #define MAX_RDD_ID ((REGION_ARRAY_SIZE)/(MAX_PARTITIONS)) //< Total different rdds
 
@@ -53,7 +52,7 @@
 
 #define MMAP_SIZE (4*1024*1024)       //< Size of small mmaps in Anonymous mode
 
-#define STATISTICS 0				  //< Enable allocator to print statistics
+#define STATISTICS 1				  //< Enable allocator to print statistics
 
 #define DEBUG_PRINT 0			      //< Enable debug prints
 

--- a/allocator/src/regions.c
+++ b/allocator/src/regions.c
@@ -90,9 +90,12 @@ char* allocate(size_t size, uint64_t rdd_id, uint64_t partition_id) {
 
 	assertf(size > 0, "Object should be > 0");
 
-    alloc_ptr = allocate_to_region(size * HEAPWORD, rdd_id, partition_id);
+  alloc_ptr = allocate_to_region(size * HEAPWORD, rdd_id, partition_id);
 
-    assertf(alloc_ptr != NULL, "No free space in H2");
+  if (alloc_ptr == NULL) {
+    perror("[Error] - H2 Allocator is full");
+    exit(EXIT_FAILURE);
+  }
 
     tc_mem_pool.size += size;
     tc_mem_pool.cur_alloc_ptr = (char *) (((uint64_t) alloc_ptr) + size * HEAPWORD);

--- a/allocator/src/segments.c
+++ b/allocator/src/segments.c
@@ -14,11 +14,11 @@ struct region region_array[REGION_ARRAY_SIZE];
 struct region *id_array[MAX_PARTITIONS * MAX_RDD_ID];
 struct offset *offset_list;
 
-int		      region_enabled;
-int			  _next_region;
+int32_t		 region_enabled;
+int32_t		 _next_region;
 
 #if STATISTICS
-unsigned int  total_deps = 0;
+uint32_t    total_deps = 0;
 double		  alloc_elapsedtime = 0.0;
 double		  free_elapsedtime = 0.0;
 #endif
@@ -27,98 +27,110 @@ double		  free_elapsedtime = 0.0;
  * Initialize region array, group array and their fields
  */
 void init_regions(){
-    uint64_t i;
-    region_enabled = -1;
-    offset_list = NULL;
+  int32_t i;
+  region_enabled = -1;
+  offset_list = NULL;
 
-#if DEBUG_PRINT
-    fprintf(stderr, "Total num of regions:%lu\n", REGION_ARRAY_SIZE);
+#if DEBUG_PRINT 
+  fprintf(stderr, "Total num of regions:%d\n", (int32_t) REGION_ARRAY_SIZE);
 #endif
 
-    for (i = 0; i < REGION_ARRAY_SIZE ; i++){
-        if (i == 0)
-            region_array[i].start_address = start_addr_mem_pool();
-        else 
-			      region_array[i].start_address = region_array[i-1].start_address + (uint64_t)REGION_SIZE; 
-        region_array[i].used = 0;
-        region_array[i].last_allocated_end = region_array[i].start_address;
-        region_array[i].last_allocated_start = NULL;
-        region_array[i].first_allocated_start = NULL;
-        region_array[i].dependency_list = NULL;
-        region_array[i].size_mapped = 0;
-        region_array[i].offset_list = NULL;
-        region_array[i].rdd_id = MAX_PARTITIONS * MAX_RDD_ID;
-        region_array[i].part_id = MAX_PARTITIONS * MAX_RDD_ID;
+  for (i = 0; i < REGION_ARRAY_SIZE ; i++) {
+    region_array[i].start_address             = (i == 0) ? start_addr_mem_pool() : (region_array[i - 1].start_address + (uint64_t) REGION_SIZE);
+    region_array[i].used                      = 0;
+    region_array[i].last_allocated_end        = region_array[i].start_address;
+    region_array[i].last_allocated_start      = NULL;
+    region_array[i].first_allocated_start     = NULL;
+    region_array[i].dependency_list           = NULL;
+#if ANONYMOUS
+    region_array[i].size_mapped               = 0;
+    region_array[i].offset_list               = NULL;
+#endif
+    region_array[i].rdd_id                    = MAX_PARTITIONS * MAX_RDD_ID;
+    region_array[i].part_id                   = MAX_PARTITIONS * MAX_RDD_ID;
 #if PR_BUFFER
-		region_array[i].pr_buffer = malloc(sizeof(struct pr_buffer));
-		region_array[i].pr_buffer->buffer = NULL;
-		region_array[i].pr_buffer->size = 0;
-		region_array[i].pr_buffer->alloc_ptr = NULL;
-		region_array[i].pr_buffer->first_obj_addr = NULL;
+    region_array[i].pr_buffer                 = malloc(sizeof(struct pr_buffer));
+    region_array[i].pr_buffer->buffer         = NULL;
+    region_array[i].pr_buffer->size           = 0;
+    region_array[i].pr_buffer->alloc_ptr      = NULL;
+    region_array[i].pr_buffer->first_obj_addr = NULL;
 #endif
+  }
+  for (i = 0; i < MAX_PARTITIONS * MAX_RDD_ID; i++) {
+    id_array[i]                               = NULL;
+  }
+    
+
+#if ANONYMOUS
+  struct offset *prev = NULL;
+  for (i = 0 ; i < DEV_SIZE / MMAP_SIZE ; i++){
+    struct offset *ptr = malloc(sizeof(struct offset));
+    ptr->offset = MMAP_SIZE * i;
+    ptr->next = NULL;
+    if (offset_list == NULL) {
+      offset_list = ptr;
+    } else {
+      prev->next = ptr;
     }
-    for (i = 0 ; i < (MAX_PARTITIONS*MAX_RDD_ID) ; i++){
-        id_array[i] = NULL;
-    }
-  
-    struct offset *prev = NULL;
-    for (i = 0 ; i < DEV_SIZE / MMAP_SIZE ; i++){
-        struct offset *ptr = malloc(sizeof(struct offset));
-        ptr->offset = MMAP_SIZE * i;
-        ptr->next = NULL;
-        if (offset_list == NULL){
-            offset_list = ptr;
-        } else {
-            prev->next = ptr;
-        }
-        prev = ptr;
-    }
+    prev = ptr;
+  }
+#endif  
 }
 
 /*
  * Returns the start of cont_regions empty regions
  */
-unsigned int get_cont_regions(unsigned int cont_regions){
-    unsigned int i;
-    unsigned int j;
+int32_t get_cont_regions(int32_t cont_regions){
+  static int32_t i = 0;
+  int32_t j, index, end_index = i;
 
-    for(i = 0 ; i < REGION_ARRAY_SIZE ; i++ ) {
-        for (j = i ; j < (i + cont_regions); j++) {
-            if (region_array[i % REGION_ARRAY_SIZE].last_allocated_end == 
-					region_array[i % REGION_ARRAY_SIZE].start_address) 
-                continue;
-            else 
-                break;
-        }
-        if (j == (i + cont_regions))
-            return i;
-        else
-            i = j;
+  for(; i < (REGION_ARRAY_SIZE + end_index); i++) {
+    for (j = i ; j < (i + cont_regions); j++) {
+      if (region_array[j % (int32_t) REGION_ARRAY_SIZE].last_allocated_end == 
+          region_array[j % (int32_t) REGION_ARRAY_SIZE].start_address) 
+        continue;
+      else
+        break;
     }
-    return -1;
+
+    // Find region
+    if (((j - 1) % (int32_t) REGION_ARRAY_SIZE) == ((i % (int32_t) REGION_ARRAY_SIZE) + cont_regions -1 )) {
+      index = i;
+      i = j % (int32_t) REGION_ARRAY_SIZE;
+      return index;
+    }
+    else
+      i = j;
+  }
+
+  return -1;
 }
+
 
 /*
  * Finds an empty region and returns its starting address
  * Arguments: size is the size of the object we want to allocate (in
  * Bytes)
+
+ * mark unused
+ *  marking phase
+        mark_used
+   precompaction phase
+      new address
  */
 char* new_region(size_t size){
-  unsigned int i;
-  unsigned int cont_regions = (size / REGION_SIZE) + 1;
-  uint64_t cur_region = get_cont_regions(cont_regions) % REGION_ARRAY_SIZE;
-
-  if (!(size <= REGION_SIZE)) {
-    perror("[Error] - H2 Allocator - Size should be less than region size");
-    exit(EXIT_FAILURE);
-  }
+  int32_t i;
+  int32_t cont_regions = (size % REGION_SIZE != 0) ? (size / REGION_SIZE) + 1 : (size / REGION_SIZE);
+  int32_t cur_region = get_cont_regions(cont_regions);
 
   if (cur_region == -1)
     return NULL;
 
   for (i = cur_region ; i < cur_region + cont_regions ; i++){
-    references(region_array[cur_region].start_address, region_array[i].start_address);
+    assertf(region_array[i].used == 0, "Error, write to an already used region");
     mark_used(region_array[i].start_address);
+    references(region_array[cur_region].start_address, region_array[i].start_address);
+    //references(region_array[i].start_address, region_array[cur_region].start_address);
     region_array[i].last_allocated_start = region_array[cur_region].start_address;
     region_array[i].first_allocated_start = region_array[cur_region].start_address;
     region_array[i].last_allocated_end = region_array[cur_region].start_address + size;
@@ -131,112 +143,148 @@ uint64_t get_id(uint64_t rdd_id, uint64_t partition_id){
     return (rdd_id % MAX_RDD_ID) * MAX_PARTITIONS + partition_id;
 }
 
-char* allocate_to_region(size_t size, uint64_t rdd_id, uint64_t partition_id){
+char* allocate_to_region(size_t size, uint64_t rdd_id, uint64_t partition_id) {
 #if STATISTICS
-    struct timeval start_time, end_time;
-    gettimeofday(&start_time, NULL);
+  struct timeval start_time, end_time;
+  gettimeofday(&start_time, NULL);
 #endif
 
 #if ANONYMOUS
-    assert(size <= (uint64_t)REGION_SIZE);
+  assert(size <= REGION_SIZE);
 #endif
 
-    uint64_t id_index = get_id(rdd_id, partition_id);
-
-    if (id_array[id_index] == NULL) {
-        char * res = new_region(size);
-        id_array[id_index] = &region_array[((res+size) - region_array[0].start_address) / ((uint64_t)REGION_SIZE)];
-        id_array[id_index]->rdd_id = rdd_id;
-        id_array[id_index]->part_id = partition_id;
-
-#if ANONYMOUS
-        uint64_t i = 0;
-        struct offset *mmap_offset = offset_list;
-        for (i = 0; i < (size/MMAP_SIZE)+1 ; i++){
-            struct offset *tmp = offset_list;
-            assert(tmp != NULL);
-            offset_list = offset_list->next;
-            tmp->next = id_array[id_index]->offset_list;
-            id_array[id_index]->offset_list = tmp;
-        }
-        char *address_mmapped = mmap(res, MMAP_SIZE * ((size/MMAP_SIZE)+1), PROT_READ|PROT_WRITE, MAP_SHARED | MAP_FIXED, fd, mmap_offset->offset);
-        id_array[id_index]->size_mapped += MMAP_SIZE * ((size/MMAP_SIZE)+1);
-        if (address_mmapped == MAP_FAILED){
-            fprintf(stderr, "mmap to file failed 1\n");
-        }
-#endif
-        return res;
-    }
+  int32_t id_index = get_id(rdd_id, partition_id);
+  if (id_array[id_index] == NULL) {
+    char* res = new_region(size);
   
-    if ((id_array[id_index]->start_address+(uint64_t)REGION_SIZE) < id_array[id_index]->last_allocated_end 
-        || size > ((id_array[id_index]->start_address+(uint64_t)REGION_SIZE) - id_array[id_index]->last_allocated_end)) {
-        char * res = new_region(size);
-        id_array[id_index] = &region_array[((res+size) - region_array[0].start_address) / ((uint64_t)REGION_SIZE)];
-        id_array[id_index]->rdd_id = rdd_id;
-        id_array[id_index]->part_id = partition_id;
-        assertf(res != NULL, "No empty region");
-      
-#if ANONYMOUS
-        uint64_t i = 0;
-        for (i = 0; i < (size/MMAP_SIZE)+1 ; i++){
-            struct offset *tmp = offset_list;
-            assert(tmp != NULL);
-            offset_list = offset_list->next;
-            tmp->next = id_array[id_index]->offset_list;
-            id_array[id_index]->offset_list = tmp;
-            char *address_mmapped = mmap(res + id_array[id_index]->size_mapped, MMAP_SIZE, PROT_READ|PROT_WRITE, MAP_SHARED | MAP_FIXED, fd, tmp->offset);
-            id_array[id_index]->size_mapped += MMAP_SIZE;
-            if (address_mmapped == MAP_FAILED){
-                fprintf(stderr, "mmap to file failed 2\n");
-            }
-        }
-#endif
-        return res;
+    if (res == NULL) {
+      perror("[Error] - H2 Allocator is full");
+      exit(EXIT_FAILURE);
     }
-    mark_used(id_array[id_index]->start_address);
-    id_array[id_index]->last_allocated_start = id_array[id_index]->last_allocated_end;
-    id_array[id_index]->last_allocated_end = id_array[id_index]->last_allocated_start + size;
+    /* If object spans more than 1 region we don't want to allocate more objects with it*/
+    if (size < (uint64_t) REGION_SIZE) {
+      id_array[id_index] = &region_array[((res+size) - region_array[0].start_address) / ((uint64_t)REGION_SIZE)];
+      id_array[id_index]->rdd_id = rdd_id;
+      id_array[id_index]->part_id = partition_id;
+    }
+
 #if ANONYMOUS
-    if (size > MMAP_SIZE || id_array[id_index]->last_allocated_end > id_array[id_index]->start_address+id_array[id_index]->size_mapped){
-        size_t missing_size =  id_array[id_index]->last_allocated_end - (id_array[id_index]->start_address + id_array[id_index]->size_mapped); 
-        uint64_t i = 0;
-        for (i = 0; i < (missing_size/MMAP_SIZE)+1 ; i++){
-            struct offset *tmp = offset_list;
-            assert(tmp != NULL);
-            offset_list = offset_list->next;
-            tmp->next = id_array[id_index]->offset_list;
-            id_array[id_index]->offset_list = tmp;
-            void *address_mmapped = mmap(id_array[id_index]->start_address + id_array[id_index]->size_mapped, MMAP_SIZE, PROT_READ|PROT_WRITE, MAP_SHARED|MAP_FIXED, fd, tmp->offset);
-            id_array[id_index]->size_mapped += MMAP_SIZE;
-            if (address_mmapped == MAP_FAILED){
-                fprintf(stderr, "mmap to file failed 3\n");
-                fprintf(stderr, "Start of region:%p\n",id_array[id_index]->start_address);
-                fprintf(stderr, "Last object ends at:%p\n",id_array[id_index]->last_allocated_start );
-                fprintf(stderr, "MMAPS needed:%zu\n",((missing_size/MMAP_SIZE)+1));
-                fprintf(stderr, "size:%zu\n",size);
-                fprintf(stderr, "missing size:%zu\n",missing_size);
-                return NULL;
-            }
-        }
+    uint64_t i = 0;
+    struct offset *mmap_offset = offset_list;
+    for (i = 0; i < (size/MMAP_SIZE)+1 ; i++){
+      struct offset *tmp = offset_list;
+      assert(tmp != NULL);
+      offset_list = offset_list->next;
+      tmp->next = id_array[id_index]->offset_list;
+      id_array[id_index]->offset_list = tmp;
+    }
+    char *address_mmapped = mmap(res, MMAP_SIZE * ((size/MMAP_SIZE)+1), PROT_READ|PROT_WRITE, MAP_SHARED | MAP_FIXED, fd, mmap_offset->offset);
+    id_array[id_index]->size_mapped += MMAP_SIZE * ((size/MMAP_SIZE)+1);
+    if (address_mmapped == MAP_FAILED){
+      fprintf(stderr, "mmap to file failed 1\n");
     }
 #endif
+
+#if DEBUG_PRINT
+    printf("Allocating from region %ld until region %ld\n",((res) - region_array[0].start_address) / ((uint64_t)REGION_SIZE),((res+size) - region_array[0].start_address) / ((uint64_t)REGION_SIZE));
+#endif
+
+    return res;
+  }
+
+  if (id_array[id_index]->last_allocated_end + size > ((id_array[id_index]->start_address + (uint64_t)REGION_SIZE))) {
+
+    char* res = new_region(size);
+    
+    if (res == NULL) {
+      perror("[Error] - H2 Allocator is full");
+      exit(EXIT_FAILURE);
+    }
+
+    /* If object spans more than 1 region we don't want to allocate more objects with it*/
+    if (size < (uint64_t) REGION_SIZE){
+      id_array[id_index] = &region_array[((res+size) - region_array[0].start_address) / ((uint64_t)REGION_SIZE)];
+      id_array[id_index]->rdd_id = rdd_id;
+      id_array[id_index]->part_id = partition_id;
+    }
+
+    assertf(res != NULL, "No empty region");
+
+#if ANONYMOUS
+    uint64_t i = 0;
+    for (i = 0; i < (size/MMAP_SIZE)+1 ; i++){
+      struct offset *tmp = offset_list;
+      assert(tmp != NULL);
+      offset_list = offset_list->next;
+      tmp->next = id_array[id_index]->offset_list;
+      id_array[id_index]->offset_list = tmp;
+      char *address_mmapped = mmap(res + id_array[id_index]->size_mapped, MMAP_SIZE, PROT_READ|PROT_WRITE, MAP_SHARED | MAP_FIXED, fd, tmp->offset);
+      id_array[id_index]->size_mapped += MMAP_SIZE;
+      if (address_mmapped == MAP_FAILED){
+        fprintf(stderr, "mmap to file failed 2\n");
+      }
+    }
+#endif
+
+#if DEBUG_PRINT
+    printf("Allocating from region %ld until region %ld\n",((res) - region_array[0].start_address) / ((uint64_t)REGION_SIZE),((res+size) - region_array[0].start_address) / ((uint64_t)REGION_SIZE));
+#endif
+
+    return res;
+  }
+
+  mark_used(id_array[id_index]->start_address);
+  id_array[id_index]->last_allocated_start = id_array[id_index]->last_allocated_end;
+  id_array[id_index]->last_allocated_end = id_array[id_index]->last_allocated_start + size;
+
+#if ANONYMOUS
+  if (size > MMAP_SIZE || id_array[id_index]->last_allocated_end > id_array[id_index]->start_address+id_array[id_index]->size_mapped){
+    size_t missing_size =  id_array[id_index]->last_allocated_end - (id_array[id_index]->start_address + id_array[id_index]->size_mapped); 
+    uint64_t i = 0;
+    for (i = 0; i < (missing_size/MMAP_SIZE)+1 ; i++){
+      struct offset *tmp = offset_list;
+      assert(tmp != NULL);
+      offset_list = offset_list->next;
+      tmp->next = id_array[id_index]->offset_list;
+      id_array[id_index]->offset_list = tmp;
+      void *address_mmapped = mmap(id_array[id_index]->start_address + id_array[id_index]->size_mapped, MMAP_SIZE, PROT_READ|PROT_WRITE, MAP_SHARED|MAP_FIXED, fd, tmp->offset);
+      id_array[id_index]->size_mapped += MMAP_SIZE;
+      if (address_mmapped == MAP_FAILED){
+        fprintf(stderr, "mmap to file failed 3\n");
+        fprintf(stderr, "Start of region:%p\n",id_array[id_index]->start_address);
+        fprintf(stderr, "Last object ends at:%p\n",id_array[id_index]->last_allocated_start );
+        fprintf(stderr, "MMAPS needed:%zu\n",((missing_size/MMAP_SIZE)+1));
+        fprintf(stderr, "size:%zu\n",size);
+        fprintf(stderr, "missing size:%zu\n",missing_size);
+        return NULL;
+      }
+    }
+  }
+#endif
+
 #if STATISTICS
-    gettimeofday(&end_time, NULL);
-    alloc_elapsedtime += (end_time.tv_sec - start_time.tv_sec) * 1000.0;
-    alloc_elapsedtime += (end_time.tv_usec - start_time.tv_usec) / 1000.0;
+  gettimeofday(&end_time, NULL);
+  alloc_elapsedtime += (end_time.tv_sec - start_time.tv_sec) * 1000.0;
+  alloc_elapsedtime += (end_time.tv_usec - start_time.tv_usec) / 1000.0;
 #endif
-    return id_array[id_index]->last_allocated_start;
+
+#if DEBUG_PRINT
+  printf("Allocating from region %ld until region %ld\n",((id_array[id_index]->last_allocated_start) - region_array[0].start_address) / ((uint64_t)REGION_SIZE),((id_array[id_index]->last_allocated_start+size) - region_array[0].start_address) / ((uint64_t)REGION_SIZE));
+#endif
+
+  return id_array[id_index]->last_allocated_start;
 }
+
 
 /*
  * function that connects two regions in a group
  * arguments: obj1: the object that references the other
- * obj2 the object that is referenced (order does not matter)
+ * obj2 the object that is referenced
  */
 
 void references(char *obj1, char *obj2){
-    int seg1 = (obj1 - region_array[0].start_address) / ((uint64_t)REGION_SIZE);
-    int seg2 = (obj2 - region_array[0].start_address) / ((uint64_t)REGION_SIZE);
+    int32_t seg1 = (obj1 - region_array[0].start_address) / ((uint64_t)REGION_SIZE);
+    int32_t seg2 = (obj2 - region_array[0].start_address) / ((uint64_t)REGION_SIZE);
     if (seg1 >= REGION_ARRAY_SIZE || seg2 >= REGION_ARRAY_SIZE || seg1 < 0 || seg2 < 0)
         return;
   
@@ -244,6 +292,7 @@ void references(char *obj1, char *obj2){
         return;
   
     struct group *ptr = region_array[seg1].dependency_list;
+
     while (ptr != NULL){
         if (ptr->region == &region_array[seg2])
             break;
@@ -252,9 +301,11 @@ void references(char *obj1, char *obj2){
     if (ptr)
         return;
     struct group *new = malloc(sizeof(struct group));
+
 #if STATISTICS
     total_deps++;
 #endif
+
     new->next = region_array[seg1].dependency_list;
     new->region = &region_array[seg2];
     region_array[seg1].dependency_list = new;
@@ -267,8 +318,8 @@ void references(char *obj1, char *obj2){
  * arguments: obj: the object that must be checked to be groupped with the region_enabled
  */
 void check_for_group(char *obj){
-    int seg1 = region_enabled;
-    int seg2 = (obj - region_array[0].start_address) / ((uint64_t)REGION_SIZE);
+    int32_t seg1 = region_enabled;
+    int32_t seg2 = (obj - region_array[0].start_address) / ((uint64_t)REGION_SIZE);
     if (seg1 >= REGION_ARRAY_SIZE || seg2 >= REGION_ARRAY_SIZE || seg1 < 0 || seg2 < 0){ 
         return;
     }
@@ -296,12 +347,12 @@ void check_for_group(char *obj){
  * prints all the region groups that contain something
  */
 void print_groups(){
-    int i;
+    int32_t i;
     fprintf(stderr, "Groups:\n");
     for (i = 0; i < REGION_ARRAY_SIZE ; i++){
         if (region_array[i].dependency_list != NULL){
             struct group *ptr = region_array[i].dependency_list;
-            printf("Region %d depends on regions:\n",i);
+            fprintf(stderr, "Region %d depends on regions:\n", i);
             while (ptr != NULL){
                 fprintf(stderr, "\tRegion %lu\n", ptr->region-region_array);
                 ptr = ptr->next;
@@ -314,7 +365,7 @@ void print_groups(){
  * Resets the used field of all regions and groups
  */
 void reset_used(){
-    int i;
+    int32_t i;
     for (i = 0 ; i < REGION_ARRAY_SIZE ; i++)
         region_array[i].used = 0;
 }
@@ -346,23 +397,20 @@ void mark_used(char *obj) {
 void print_statistics(){
     uint64_t wasted_space = 0;
     uint64_t total_regions = 0;
-    int i;
-    int flag = 0;
+    int32_t i;
+
     for(i = 0 ; i < REGION_ARRAY_SIZE ; i++ ) {
         if (region_array[i % REGION_ARRAY_SIZE].last_allocated_end != region_array[i % REGION_ARRAY_SIZE].start_address ) {
             total_regions++;
             if (region_array[i].last_allocated_end <= region_array[i].start_address + REGION_SIZE){ 
                 wasted_space += (region_array[i].start_address + (uint64_t) REGION_SIZE) - region_array[i].last_allocated_end; 
-                if (flag == 0){
-                    flag++;
-                }
             }
         }
     }
-    fprintf(stderr, "Total Wasted Space: %zu GBytes\n", wasted_space/(1024*1024*1024));
+    fprintf(stderr, "Total Wasted Space: %zu MBytes\n", wasted_space / (1024 * 1024));
     fprintf(stderr, "Total regions: %zu\n", total_regions);
     if (total_regions)
-        fprintf(stderr, "Average wasted space: %zu MBytes\n", wasted_space/(1024*1024*total_regions));
+        fprintf(stderr, "Average wasted space: %zu KBytes\n", wasted_space / (1024 * total_regions));
     fprintf(stderr, "Total dependencies:%d\n", total_deps);
     fprintf(stderr, "Total time spent in allocate_to_region:%f ms\n", alloc_elapsedtime);
     fprintf(stderr, "Total time spent in free_regions:%f ms\n", free_elapsedtime);
@@ -372,68 +420,75 @@ void print_statistics(){
 /*
  * Frees all unused regions
  */
-struct region_list* free_regions(){
+struct region_list* free_regions() {
 #if STATISTICS
-    struct timeval t1,t2;
-    gettimeofday(&t1, NULL);
+  struct timeval t1,t2;
+  gettimeofday(&t1, NULL);
 #endif
-    int i;
-    struct region_list *head = NULL;
-    for (i = 0; i < REGION_ARRAY_SIZE ; i++){
-        if (region_array[i].used == 0 && region_array[i].last_allocated_end != region_array[i].start_address){
-            struct group *ptr = region_array[i].dependency_list;
-            struct group *next = NULL;
-            while (ptr != NULL) {
-                next = ptr->next;
-                free(ptr);
-                ptr = next;
-            }
-            region_array[i].dependency_list = NULL;
-            struct region_list *new_node = malloc(sizeof(struct region_list));
-            new_node->start = region_array[i].start_address;
-            new_node->end = region_array[i].last_allocated_start;
-            new_node->next = head;
-            head = new_node;
-            region_array[i].last_allocated_end = region_array[i].start_address;
-            region_array[i].last_allocated_start = NULL;
-            region_array[i].first_allocated_start = NULL;
-            
+  int32_t i;
+  struct region_list *head = NULL;
+  for (i = 0; i < REGION_ARRAY_SIZE ; i++){
+    if (region_array[i].used == 0 && region_array[i].last_allocated_end != region_array[i].start_address){
+      struct group *ptr = region_array[i].dependency_list;
+      struct group *next = NULL;
+      while (ptr != NULL) {
+        next = ptr->next;
+        free(ptr);
+#if STATISTICS
+        total_deps--;
+#endif
+        ptr = next;
+      }
+      region_array[i].dependency_list = NULL;
+
+      if (region_array[i].last_allocated_start >= region_array[i].start_address) {
+        struct region_list *new_node = malloc(sizeof(struct region_list));
+        new_node->start = region_array[i].start_address;
+        new_node->end = region_array[i].last_allocated_start;
+        new_node->next = head;
+        head = new_node;
+      }
+
+      region_array[i].last_allocated_end = region_array[i].start_address;
+      region_array[i].last_allocated_start = NULL;
+      region_array[i].first_allocated_start = NULL;
+
 #if ANONYMOUS 
-            region_array[i].size_mapped = 0;
-            struct offset *offset_ptr = region_array[i].offset_list;
-            struct offset *temp = offset_ptr;
-            while (offset_ptr != NULL){
-               temp = offset_ptr->next;
-               offset_ptr->next = offset_list;
-               offset_list = offset_ptr;
-               offset_ptr = temp;
-            }
-            region_array[i].offset_list = NULL;
+      region_array[i].size_mapped = 0;
+      struct offset *offset_ptr = region_array[i].offset_list;
+      struct offset *temp = offset_ptr;
+      while (offset_ptr != NULL){
+        temp = offset_ptr->next;
+        offset_ptr->next = offset_list;
+        offset_list = offset_ptr;
+        offset_ptr = temp;
+      }
+      region_array[i].offset_list = NULL;
 #endif
-            if (id_array[region_array[i].rdd_id] == &region_array[i]){
-                id_array[region_array[i].rdd_id] = NULL;
-            }
-            region_array[i].rdd_id = MAX_PARTITIONS * MAX_RDD_ID;
+      if (id_array[get_id(region_array[i].rdd_id, region_array[i].part_id)] == &region_array[i]) {
+        id_array[get_id(region_array[i].rdd_id, region_array[i].part_id)] = NULL;
+      }
+      region_array[i].rdd_id = MAX_PARTITIONS * MAX_RDD_ID;
 
 #if STATISTICS
-            fprintf(stderr, "Freeing region %d \n",i);
+      fprintf(stderr, "Freeing region %d \n",i);
 #endif
-        }
     }
+  }
 #if STATISTICS
-    print_statistics();
-    gettimeofday(&t2, NULL);
-    free_elapsedtime += (t2.tv_sec - t1.tv_sec) * 1000.0;
-    free_elapsedtime += (t2.tv_usec - t1.tv_usec) / 1000.0;
+  print_statistics();
+  gettimeofday(&t2, NULL);
+  free_elapsedtime += (t2.tv_sec - t1.tv_sec) * 1000.0;
+  free_elapsedtime += (t2.tv_usec - t1.tv_usec) / 1000.0;
 #endif
-    return head;
+  return head;
 }
 
 /*
  * Prints all the allocated regions
  */
 void print_regions(){
-    int i;
+    int32_t i;
     fprintf(stderr, "Regions:\n");
     for (i = 0; i < REGION_ARRAY_SIZE ; i++){
         if (region_array[i].last_allocated_end != region_array[i].start_address)
@@ -445,7 +500,7 @@ void print_regions(){
  * Prints all the used regions
  */
 void print_used_regions(){
-    int i;
+    int32_t i;
     fprintf(stderr, "Used Regions:\n");
     for (i = 0 ; i < REGION_ARRAY_SIZE ; i++){
         if (region_array[i].used == 1)
@@ -479,21 +534,23 @@ bool is_region_start(char *obj){
 	assertf(seg >= 0 && seg < REGION_ARRAY_SIZE,
 			"Segment index is out of range %lu", seg); 
 
-	return (region_array[seg].start_address == obj) ? true : false;
+	return (region_array[seg].first_allocated_start == obj) ? true : false;
 }
 
 /*
  * Enables groupping with the region in which obj belongs to
  */
 void enable_region_groups(char *obj){
-    region_enabled = (obj - region_array[0].start_address) / ((uint64_t)REGION_SIZE);
+  region_enabled = ((uint64_t)(obj - region_array[0].start_address)) / ((uint64_t) REGION_SIZE);
+  assertf(region_enabled > 0 && region_enabled < INT32_MAX, "Sanity check for overflow");
 }
 
 /*
  * Disables groupping with the region previously enabled
  */
 void disable_region_groups(void){
-    region_enabled = REGION_ARRAY_SIZE;
+  region_enabled = REGION_ARRAY_SIZE;
+  assertf(region_enabled > 0 && region_enabled < INT32_MAX, "Sanity check for overflow");
 }
 
 
@@ -513,30 +570,36 @@ void start_iterate_regions() {
  * array.
  */
 char* get_next_region() {
-	char *region_start_addr;
+  char *region_start_addr;
 
-	// Find the next active region
-	while (_next_region < REGION_ARRAY_SIZE &&
-			region_array[_next_region].used == 0) {
-		_next_region++; 
-	}
+  // Find the next active region
+  while (_next_region < REGION_ARRAY_SIZE &&
+    (region_array[_next_region].used == 0 || region_array[_next_region].first_allocated_start != region_array[_next_region].start_address)) {
+      _next_region++; 
+  }
 
-	if (_next_region >= REGION_ARRAY_SIZE)
-		return NULL;
+  if (_next_region >= REGION_ARRAY_SIZE)
+    return NULL;
 
-	fprintf(stderr, "[PLACEMENT] Region: %d\n", _next_region);
+  fprintf(stderr, "[PLACEMENT] Region: %d\n", _next_region);
 
-	region_start_addr = region_array[_next_region].start_address;
-	_next_region++;
+  region_start_addr = region_array[_next_region].start_address;
+  _next_region++;
 
-	return region_start_addr;
+  return region_start_addr;
 }
 
 char *get_first_object(char *addr) {
-    uint64_t seg = (addr - region_array[0].start_address) / ((uint64_t)REGION_SIZE);
-	assertf(seg >= 0 && seg < REGION_ARRAY_SIZE,
-			"Segment index is out of range %lu", seg); 
-    return region_array[seg].first_allocated_start;
+  uint64_t seg = (addr - region_array[0].start_address) / ((uint64_t)REGION_SIZE);
+  assertf(seg >= 0 && seg < REGION_ARRAY_SIZE, "Segment index is out of range %lu", seg); 
+  return region_array[seg].first_allocated_start;
+}
+
+int get_num_of_continuous_regions(char *addr){
+  uint64_t seg = (addr - region_array[0].start_address) / ((uint64_t)REGION_SIZE);
+  return ((region_array[seg].last_allocated_end - region_array[seg].first_allocated_start) % (uint64_t)REGION_SIZE != 0) ? 
+  (region_array[seg].last_allocated_end - region_array[seg].first_allocated_start) / (uint64_t)REGION_SIZE + 1 :
+  (region_array[seg].last_allocated_end - region_array[seg].first_allocated_start) / (uint64_t)REGION_SIZE ; 
 }
 
 /*
@@ -557,11 +620,10 @@ char* get_region_start_addr(char *obj, uint64_t rdd_id, uint64_t part_id) {
  * Return: the object rdd id
  */
 uint64_t get_obj_group_id(char *obj) {
-    uint64_t seg = (obj - region_array[0].start_address) / ((uint64_t)REGION_SIZE);
-	assertf(seg >= 0 && seg < REGION_ARRAY_SIZE,
-			"Segment index is out of range %lu", seg); 
-	return region_array[seg].rdd_id;
-
+  uint64_t seg = (obj - region_array[0].start_address) / ((uint64_t)REGION_SIZE);
+  assertf(seg >= 0 && seg < REGION_ARRAY_SIZE,
+          "Segment index is out of range %lu", seg); 
+  return region_array[seg].rdd_id;
 }
 
 /*
@@ -573,11 +635,11 @@ uint64_t get_obj_group_id(char *obj) {
  * returns: the object partition Id
  */
 uint64_t get_obj_part_id(char *obj) {
-    uint64_t seg = (obj - region_array[0].start_address) / ((uint64_t)REGION_SIZE);
-	assertf(seg >= 0 && seg < REGION_ARRAY_SIZE,
-			"Segment index is out of range %lu", seg); 
+  uint64_t seg = (obj - region_array[0].start_address) / ((uint64_t)REGION_SIZE);
+  assertf(seg >= 0 && seg < REGION_ARRAY_SIZE,
+          "Segment index is out of range %lu", seg); 
 
-	return region_array[seg].part_id;
+  return region_array[seg].part_id;
 }
 
 /*
@@ -613,7 +675,7 @@ int is_in_the_same_group(char *obj1, char *obj2) {
  * Return the total number of allocated regions or zero, otherwise              
  */                                                                             
 long total_allocated_regions() {                                                
-	int i;                                                                      
+	int32_t i;                                                                      
 	long counter = 0;                                                           
 
 	for (i = 0; i < REGION_ARRAY_SIZE; i++){                                   
@@ -629,7 +691,7 @@ long total_allocated_regions() {
  * Return the total number of used regions or zero, otherwise                   
  */                                                                             
 long total_used_regions() {                                                     
-	int i;                                                                      
+	int32_t i;                                                                      
 	long counter = 0;                                                           
 
 	for (i = 0 ; i < REGION_ARRAY_SIZE; i++) {                                 
@@ -754,5 +816,12 @@ void free_all_buffers() {
 			buf->size = 0;
 		}
 	}
+}
+
+bool object_starts_from_region(char *obj) {
+  uint64_t seg = (obj - region_array[0].start_address) / ((uint64_t)REGION_SIZE);
+  assertf(seg >= 0 && seg < REGION_ARRAY_SIZE,
+          "Segment index is out of range %lu", seg); 
+  return (region_array[seg].first_allocated_start != region_array[seg].start_address) ? false : true;
 }
 #endif

--- a/allocator/src/segments.c
+++ b/allocator/src/segments.c
@@ -427,7 +427,7 @@ struct region_list* free_regions() {
 #endif
   int32_t i;
   struct region_list *head = NULL;
-  for (i = 0; i < REGION_ARRAY_SIZE ; i++){
+  for (i = 0; i < REGION_ARRAY_SIZE; i++){
     if (region_array[i].used == 0 && region_array[i].last_allocated_end != region_array[i].start_address){
       struct group *ptr = region_array[i].dependency_list;
       struct group *next = NULL;

--- a/allocator/tests/tc_allocate_multi_regions.c
+++ b/allocator/tests/tc_allocate_multi_regions.c
@@ -1,0 +1,81 @@
+
+/***************************************************
+*
+* file: tc_allocate.c
+*
+* @Author:   Iacovos G. Kolokasis
+* @Author:   Giannos Evdorou
+* @Version:  09-03-2021
+* @email:    kolokasis@ics.forth.gr
+*
+* Test to verify:
+*       - allocator initialization
+*       - object allocation in the correct positions
+***************************************************/
+
+#include <stdint.h>
+#include <stdio.h>
+#include "../include/sharedDefines.h"
+#include "../include/regions.h"
+#include "../include/segments.h"
+
+#define CARD_SIZE ((uint64_t) (1 << 9))
+#define PAGE_SIZE ((uint64_t) (1 << 12))
+
+#define SIZE_30MB (3932160)
+#define SIZE_5MB (655360)
+#define SIZE_1MB (131072)
+#define SIZE_2MB (262144)
+
+//this test needs 256MB region size
+int main() {
+  char *obj1, *obj2, *obj3, *obj4, *obj5, *obj6;
+
+  // Init allocator
+  init(CARD_SIZE * PAGE_SIZE);
+
+  //obj1 should be in region 0
+  obj1 = allocate(1, 0, 0);
+  fprintf(stderr, "Allocate: %p\n", obj1);
+
+  //obj2 should be in region 1 
+  obj2 = allocate(200, 1, 0);
+  fprintf(stderr, "Allocate: %p\n", obj2);
+
+  //obj3 should be in region 0
+  obj3 = allocate(SIZE_5MB, 0, 0);
+  fprintf(stderr, "Allocate: %p\n", obj3);
+
+  obj4 = allocate(SIZE_1MB, 2, 0);
+  fprintf(stderr, "Allocate: %p\n", obj4);
+
+  obj5 = allocate(10, 2, 0);
+  fprintf(stderr, "Allocate: %p\n", obj5);
+
+  obj6 = allocate(10, 0, 0);
+  fprintf(stderr, "Allocate: %p\n", obj6);
+  
+
+  reset_used();
+  mark_used(obj3);
+  mark_used(obj4);
+  mark_used(obj6);
+  
+  //obj2 should be in region 1 
+  obj2 = allocate(64000, 10, 0);
+  fprintf(stderr, "Allocate: %p\n", obj2);
+
+  free_regions();
+
+  obj3 = allocate(SIZE_2MB, 4, 0);
+  fprintf(stderr, "Allocate: %p\n", obj3);
+  
+  free_regions();
+  
+  obj3 = allocate(SIZE_1MB, 4, 0);
+  fprintf(stderr, "Allocate: %p\n", obj3);
+
+  //free_regions();
+
+  return 0;
+}

--- a/jdk8u345/hotspot/src/share/vm/classfile/classLoaderData.cpp
+++ b/jdk8u345/hotspot/src/share/vm/classfile/classLoaderData.cpp
@@ -146,6 +146,13 @@ void ClassLoaderData::oops_do(OopClosure* f, KlassClosure* klass_closure, bool m
     return;
   }
 
+#ifdef P_SD_EXCLUDE_CLOSURE
+  if (EnableTeraHeap && _class_loader != NULL) {
+    if (_class_loader->is_marked_move_h2())
+      _class_loader->init_obj_state();
+  }
+#endif
+
   f->do_oop(&_class_loader);
   _dependencies.oops_do(f);
   _handles.oops_do(f);

--- a/jdk8u345/hotspot/src/share/vm/gc_implementation/parallelScavenge/cardTableExtension.cpp
+++ b/jdk8u345/hotspot/src/share/vm/gc_implementation/parallelScavenge/cardTableExtension.cpp
@@ -372,7 +372,8 @@ void CardTableExtension::h2_scavenge_contents_parallel(ObjectStartArray* start_a
 		if (worker_start_card >= end_card)
 			return; // We're done.
 
-		jbyte* worker_end_card = worker_start_card + ssize;
+    jbyte* worker_end_card = worker_start_card + 
+      Universe::teraHeap()->h2_continuous_regions(addr_for(worker_start_card)) * ssize;
 		if (worker_end_card > end_card) {
 			worker_end_card = end_card;
 		}
@@ -391,7 +392,8 @@ void CardTableExtension::h2_scavenge_contents_parallel(ObjectStartArray* start_a
 			continue;
 
 		// Update our beginning addr
-    if (!Universe::teraHeap()->check_if_valid_object(slice_start))
+    if (!Universe::teraHeap()->check_if_valid_object(slice_start) || 
+      !Universe::teraHeap()->is_start_of_region(slice_start))
       continue;
 
     HeapWord* first_object = Universe::teraHeap()->get_first_object_in_region(slice_start);

--- a/jdk8u345/hotspot/src/share/vm/gc_implementation/parallelScavenge/psMarkSweepDecorator.cpp
+++ b/jdk8u345/hotspot/src/share/vm/gc_implementation/parallelScavenge/psMarkSweepDecorator.cpp
@@ -425,6 +425,9 @@ void PSMarkSweepDecorator::moveObjToH2(HeapWord *q, HeapWord *compaction_top, si
   if (!H2LivenessAnalysis)
     // Change the value of teraflag in the new location of the object
     oop(compaction_top)->set_in_h2();
+  else {
+      oop(compaction_top)->set_live();
+    }
 
   /* Initialize mark word of the destination */
   oop(compaction_top)->init_mark();

--- a/jdk8u345/hotspot/src/share/vm/gc_implementation/teraHeap/teraHeap.hpp
+++ b/jdk8u345/hotspot/src/share/vm/gc_implementation/teraHeap/teraHeap.hpp
@@ -353,6 +353,11 @@ public:
   void set_low_promotion_threshold();
 #endif
 
+  // Check if the object with `addr` span multiple regions
+  int h2_continuous_regions(HeapWord *addr);
+
+  // Check where the object starts
+  bool h2_object_starts_in_region(HeapWord *obj);
 };
 
 #endif

--- a/jdk8u345/hotspot/src/share/vm/oops/instanceClassLoaderKlass.cpp
+++ b/jdk8u345/hotspot/src/share/vm/oops/instanceClassLoaderKlass.cpp
@@ -125,6 +125,12 @@ void InstanceClassLoaderKlass::oop_follow_contents(oop obj) {
 	DEBUG_ONLY(if (EnableTeraHeap) { assert(!Universe::teraHeap()->is_obj_in_h2(obj), "Object is in TeraHeap"); });
 #endif
 
+#ifdef P_SD_EXCLUDE_CLOSURE
+  if (EnableTeraHeap && obj->is_marked_move_h2()) {
+    obj->init_obj_state();
+  }
+#endif
+
   InstanceKlass::oop_follow_contents(obj);
   ClassLoaderData * const loader_data = java_lang_ClassLoader::loader_data(obj);
 

--- a/jdk8u345/hotspot/src/share/vm/oops/objArrayKlass.inline.hpp
+++ b/jdk8u345/hotspot/src/share/vm/oops/objArrayKlass.inline.hpp
@@ -90,8 +90,8 @@ void ObjArrayKlass::h2_objarray_follow_contents(oop obj, int index) {
   const size_t beg_index = size_t(index);
   assert(beg_index < len || len == 0, "index too large");
 
-  const size_t stride = MIN2(len - beg_index, ObjArrayMarkingStride);
-  const size_t end_index = beg_index + stride;
+  //const size_t stride = MIN2(len - beg_index, ObjArrayMarkingStride);
+  const size_t end_index = beg_index + len;
   T* const base = (T*)a->base();
   T* const beg = base + beg_index;
   T* const end = base + end_index;

--- a/jdk8u345/hotspot/src/share/vm/oops/oop.hpp
+++ b/jdk8u345/hotspot/src/share/vm/oops/oop.hpp
@@ -138,7 +138,9 @@ class oopDesc {
   }
 
   bool is_live(){
-	  return ((_tera_flag & 0xffffffff) == LIVE_TERA_OBJ || (_tera_flag & 0xffffffff) == VISITED_TERA_OBJ || (_tera_flag & 0xffffffff) == MOVE_TO_TERA );
+    return (get_obj_state() == LIVE_TERA_OBJ || 
+            get_obj_state() == VISITED_TERA_OBJ || 
+            get_obj_state() == MOVE_TO_TERA);
   }
 
   void reset_live(){
@@ -166,7 +168,7 @@ class oopDesc {
   }
 
   bool is_visited(){
-	  return (_tera_flag & 0xffffffff) == VISITED_TERA_OBJ;
+	  return (get_obj_state() == VISITED_TERA_OBJ);
   }
 
 #endif // TERA_FLAG

--- a/jdk8u345/hotspot/src/share/vm/oops/typeArrayKlass.cpp
+++ b/jdk8u345/hotspot/src/share/vm/oops/typeArrayKlass.cpp
@@ -212,6 +212,8 @@ void TypeArrayKlass::oop_follow_contents(oop obj) {
 
 #ifdef TERA_MAJOR_GC
 void TypeArrayKlass::h2_oop_follow_contents(oop obj) {
+  if (H2LivenessAnalysis)
+    obj->set_live();
   assert(obj->is_typeArray(),"must be a type array");
   // Performance tweak: We skip iterating over the klass pointer since we
   // know that Universe::TypeArrayKlass never moves.

--- a/jdk8u345/hotspot/src/share/vm/prims/unsafe.cpp
+++ b/jdk8u345/hotspot/src/share/vm/prims/unsafe.cpp
@@ -663,7 +663,7 @@ UNSAFE_ENTRY(void, Unsafe_h2TagAndMoveRoot(JNIEnv *env, jobject unsafe,
   	return;
 
   // Initialize object's teraflag
-  o->mark_move_h2(label, partId);
+  o->mark_move_h2(label, 0);
 UNSAFE_END
 
 UNSAFE_ENTRY(void, Unsafe_h2TagRoot(JNIEnv *env, jobject unsafe,
@@ -680,7 +680,7 @@ UNSAFE_ENTRY(void, Unsafe_h2TagRoot(JNIEnv *env, jobject unsafe,
   	return;
 
   // Initialize object's teraflag
-  o->mark_move_h2(Universe::teraHeap()->get_non_promote_tag(), partId);
+  o->mark_move_h2(Universe::teraHeap()->get_non_promote_tag(), 0);
 UNSAFE_END
 
 UNSAFE_ENTRY(void, Unsafe_h2Move(JNIEnv *env, jobject unsafe,


### PR DESCRIPTION
We extend the allocator to use small-sized regions (e.g., 16 MB). For objects that are larger than the region size, we allocate them to contiguous regions.

Other fixes:
- Fix H2 liveness analysis to track scan and identify live H2 objects correctly
- Fix the H2 policy for the high-low-threshold option to move only the marked objects for H2 promotion. 
